### PR TITLE
Добавлен виджет динамического каталога устройств BDView

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-31T11:40:51.662Z for PR creation at branch issue-31-26559583a839 for issue https://github.com/veb86/GristWidgets/issues/31

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-31T11:40:51.662Z for PR creation at branch issue-31-26559583a839 for issue https://github.com/veb86/GristWidgets/issues/31

--- a/experiments/verify-bdview-database.js
+++ b/experiments/verify-bdview-database.js
@@ -1,0 +1,29 @@
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const CategoryTree = require('../widget/BDView/js/category-tree.js');
+const ColumnProvider = require('../widget/BDView/js/column-provider.js');
+const DeviceProvider = require('../widget/BDView/js/device-provider.js');
+const ParameterProvider = require('../widget/BDView/js/parameter-provider.js');
+const TableBuilder = require('../widget/BDView/js/table-builder.js');
+
+function query(table) {
+  return JSON.parse(execFileSync('sqlite3', ['-json', 'BDNEW_ZCAD.grist', `select * from "${table}"`], { encoding: 'utf8' }) || '[]');
+}
+
+const categories = query('Categories');
+const categoryParameters = query('CategoryParameters');
+const devices = query('Devices');
+const parameters = query('Parameters');
+const deviceParameters = query('DeviceParameters');
+
+const categoryIds = CategoryTree.descendantIds(categories, 2);
+const selectedParameters = ColumnProvider.forCategory(categoryParameters, parameters, 2);
+const selectedDevices = DeviceProvider.forCategories(devices, categoryIds);
+const values = ParameterProvider.mapForDevices(deviceParameters, selectedDevices.map((device) => device.id), selectedParameters);
+const rows = TableBuilder.rows(selectedDevices, selectedParameters, values);
+
+assert.ok(categoryIds.includes(2));
+assert.deepEqual(selectedParameters.map((parameter) => parameter.name), ['Мощность', 'Напряжение', 'Цветовая температура']);
+assert.equal(rows.length, 1);
+assert.deepEqual(rows[0], { id: 1, parameter_1: 10, parameter_2: 220, parameter_4: 4000 });
+console.log('BDView database verification passed:', { categoryIds: categoryIds.length, columns: selectedParameters.length, rows: rows.length });

--- a/widget/BDView/README.md
+++ b/widget/BDView/README.md
@@ -1,0 +1,22 @@
+# BDView
+
+Виджет Grist Desktop строит таблицу устройств по категории, выбранной в `SYSTEM.selectedGroupID`.
+
+Колонки берутся из `CategoryParameters` в порядке `manualSort`; строки включают устройства выбранной категории и всех её потомков. Значения загружаются одним чтением `DeviceParameters`, затем сопоставляются в памяти. Каждый столбец поддерживает сортировку и регистронезависимый поиск по части текста средствами Tabulator.
+
+## Таблицы
+
+- `SYSTEM`: `param`, `value`.
+- `Categories`: `parent_id`.
+- `CategoryParameters`: `category_id`, `parameter_id`, `manualSort`.
+- `Parameters`: `name`, `unit`, `data_type`.
+- `Devices`: `categories_id`.
+- `DeviceParameters`: `device_id`, `parameter_id`, `value_float`, `value_int`, `value_string`.
+
+Добавьте Custom Widget с URL `widget/BDView/index.html` и предоставьте доступ к документу. Виджет проверяет `SYSTEM` без перезагрузки страницы и полностью перестраивает Tabulator при смене категории.
+
+## Тесты
+
+```bash
+node --test widget/BDView/tests/*.test.js
+```

--- a/widget/BDView/css/style.css
+++ b/widget/BDView/css/style.css
@@ -1,0 +1,15 @@
+* { box-sizing: border-box; }
+html, body { height: 100%; margin: 0; }
+body { color: #252525; font: 14px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+.widget { display: flex; flex-direction: column; height: 100%; min-height: 180px; }
+.header { align-items: center; border-bottom: 1px solid #ddd; display: flex; gap: 16px; min-height: 48px; padding: 10px 14px; }
+.header h1 { font-size: 17px; margin: 0; }
+#summary { color: #666; margin-left: auto; white-space: nowrap; }
+#message { padding: 0 14px; }
+#message.info, #message.error { padding-bottom: 9px; padding-top: 9px; }
+#message.info { background: #f3f7fa; color: #456; }
+#message.error { background: #fff0f0; color: #a22; }
+#device-table { flex: 1; min-height: 0; }
+.tabulator { border: 0; font-size: 13px; }
+.tabulator .tabulator-header .tabulator-col .tabulator-col-content { padding: 7px; }
+.tabulator .tabulator-header-filter input { border: 1px solid #bbb; border-radius: 3px; padding: 4px 6px; }

--- a/widget/BDView/index.html
+++ b/widget/BDView/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Динамический каталог устройств</title>
+  <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+  <link rel="stylesheet" href="./css/style.css">
+</head>
+<body>
+  <main class="widget">
+    <header class="header"><h1>Каталог устройств</h1><span id="summary"></span></header>
+    <div id="message" aria-live="polite"></div>
+    <div id="device-table"></div>
+  </main>
+  <script src="./grist-plugin-api.js"></script>
+  <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+  <script src="./js/data-utils.js"></script>
+  <script src="./js/system-monitor.js"></script>
+  <script src="./js/category-tree.js"></script>
+  <script src="./js/column-provider.js"></script>
+  <script src="./js/device-provider.js"></script>
+  <script src="./js/parameter-provider.js"></script>
+  <script src="./js/table-builder.js"></script>
+  <script src="./js/table-view.js"></script>
+  <script src="./js/app.js"></script>
+</body>
+</html>

--- a/widget/BDView/js/app.js
+++ b/widget/BDView/js/app.js
@@ -1,0 +1,48 @@
+(function(root) {
+  'use strict';
+  var refreshNumber = 0;
+
+  function message(text, kind) {
+    var element = document.getElementById('message');
+    element.textContent = text || '';
+    element.className = kind || '';
+  }
+
+  async function load(selectedId) {
+    var thisRefresh = ++refreshNumber;
+    if (selectedId === null) {
+      TableView.clear();
+      message('Выберите категорию в дереве каталога.', 'info');
+      return;
+    }
+    message('Загрузка данных…', 'info');
+    try {
+      var names = ['Categories', 'CategoryParameters', 'Devices', 'Parameters', 'DeviceParameters'];
+      var raw = await Promise.all(names.map(function(name) { return grist.docApi.fetchTable(name); }));
+      if (thisRefresh !== refreshNumber) return;
+      var data = raw.map(BDViewDataUtils.rows);
+      var categoryIds = CategoryTree.descendantIds(data[0], selectedId);
+      var parameters = ColumnProvider.forCategory(data[1], data[3], selectedId);
+      var devices = DeviceProvider.forCategories(data[2], categoryIds);
+      var values = ParameterProvider.mapForDevices(data[4], devices.map(function(device) { return device.id; }), parameters);
+      TableView.rebuild(TableBuilder.columns(parameters), TableBuilder.rows(devices, parameters, values));
+      message(parameters.length ? '' : 'Для выбранной категории столбцы не настроены.', parameters.length ? '' : 'info');
+      document.getElementById('summary').textContent = 'Устройств: ' + devices.length;
+    } catch (error) {
+      console.error('[BDView] Не удалось перестроить таблицу', error);
+      TableView.clear();
+      message('Не удалось загрузить данные: ' + error.message, 'error');
+    }
+  }
+
+  function initialize() {
+    grist.ready({ requiredAccess: 'full' });
+    TableView.clear();
+    SystemMonitor.create(grist, load, {
+      onError: function(error) { message('Не удалось прочитать SYSTEM: ' + error.message, 'error'); }
+    }).start();
+  }
+
+  root.BDViewApp = { initialize: initialize, load: load };
+  document.addEventListener('DOMContentLoaded', initialize);
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/widget/BDView/js/category-tree.js
+++ b/widget/BDView/js/category-tree.js
@@ -1,0 +1,33 @@
+(function(root, factory) {
+  var moduleValue = factory(root.BDViewDataUtils || (typeof require === 'function' ? require('./data-utils.js') : null));
+  if (typeof module === 'object' && module.exports) module.exports = moduleValue;
+  root.CategoryTree = moduleValue;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function(DataUtils) {
+  'use strict';
+
+  function descendantIds(categories, selectedId) {
+    selectedId = DataUtils.normalizeId(selectedId);
+    if (selectedId === null) return [];
+    var children = new Map();
+    (categories || []).forEach(function(category) {
+      var parentId = DataUtils.normalizeId(category.parent_id);
+      var id = DataUtils.normalizeId(category.id);
+      if (id === null) return;
+      if (!children.has(parentId)) children.set(parentId, []);
+      children.get(parentId).push(id);
+    });
+    var result = [];
+    var visited = new Set();
+    var pending = [selectedId];
+    while (pending.length) {
+      var id = pending.shift();
+      if (visited.has(id)) continue;
+      visited.add(id);
+      result.push(id);
+      (children.get(id) || []).forEach(function(childId) { pending.push(childId); });
+    }
+    return result;
+  }
+
+  return { descendantIds: descendantIds };
+});

--- a/widget/BDView/js/column-provider.js
+++ b/widget/BDView/js/column-provider.js
@@ -1,0 +1,30 @@
+(function(root, factory) {
+  var moduleValue = factory(root.BDViewDataUtils || (typeof require === 'function' ? require('./data-utils.js') : null));
+  if (typeof module === 'object' && module.exports) module.exports = moduleValue;
+  root.ColumnProvider = moduleValue;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function(DataUtils) {
+  'use strict';
+
+  function forCategory(categoryParameters, parameters, selectedId) {
+    selectedId = DataUtils.normalizeId(selectedId);
+    var parameterMap = new Map((parameters || []).map(function(parameter) {
+      return [DataUtils.normalizeId(parameter.id), parameter];
+    }));
+    return (categoryParameters || [])
+      .filter(function(link) { return DataUtils.normalizeId(link.category_id) === selectedId; })
+      .sort(function(a, b) { return Number(a.manualSort || 0) - Number(b.manualSort || 0); })
+      .map(function(link) {
+        var parameterId = DataUtils.normalizeId(link.parameter_id);
+        var parameter = parameterMap.get(parameterId);
+        return parameter && {
+          id: parameterId,
+          name: parameter.name || ('Параметр ' + parameterId),
+          unit: parameter.unit || '',
+          dataType: parameter.data_type || 'string'
+        };
+      })
+      .filter(Boolean);
+  }
+
+  return { forCategory: forCategory };
+});

--- a/widget/BDView/js/data-utils.js
+++ b/widget/BDView/js/data-utils.js
@@ -1,0 +1,28 @@
+(function(root, factory) {
+  var moduleValue = factory();
+  if (typeof module === 'object' && module.exports) module.exports = moduleValue;
+  root.BDViewDataUtils = moduleValue;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function() {
+  'use strict';
+
+  function rows(tableData) {
+    if (!tableData || !Array.isArray(tableData.id)) return [];
+    var columns = Object.keys(tableData).filter(function(column) { return column !== 'id'; });
+    return tableData.id.map(function(id, index) {
+      var row = { id: id };
+      columns.forEach(function(column) {
+        row[column] = Array.isArray(tableData[column]) ? tableData[column][index] : undefined;
+      });
+      return row;
+    });
+  }
+
+  function normalizeId(value) {
+    if (Array.isArray(value) && value[0] === 'L') value = value[1];
+    if (value === null || value === undefined || value === '') return null;
+    var number = Number(value);
+    return Number.isFinite(number) ? number : null;
+  }
+
+  return { rows: rows, normalizeId: normalizeId };
+});

--- a/widget/BDView/js/device-provider.js
+++ b/widget/BDView/js/device-provider.js
@@ -1,0 +1,16 @@
+(function(root, factory) {
+  var moduleValue = factory(root.BDViewDataUtils || (typeof require === 'function' ? require('./data-utils.js') : null));
+  if (typeof module === 'object' && module.exports) module.exports = moduleValue;
+  root.DeviceProvider = moduleValue;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function(DataUtils) {
+  'use strict';
+
+  function forCategories(devices, categoryIds) {
+    var allowed = new Set((categoryIds || []).map(DataUtils.normalizeId));
+    return (devices || []).filter(function(device) {
+      return allowed.has(DataUtils.normalizeId(device.categories_id));
+    });
+  }
+
+  return { forCategories: forCategories };
+});

--- a/widget/BDView/js/parameter-provider.js
+++ b/widget/BDView/js/parameter-provider.js
@@ -1,0 +1,35 @@
+(function(root, factory) {
+  var moduleValue = factory(root.BDViewDataUtils || (typeof require === 'function' ? require('./data-utils.js') : null));
+  if (typeof module === 'object' && module.exports) module.exports = moduleValue;
+  root.ParameterProvider = moduleValue;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function(DataUtils) {
+  'use strict';
+
+  function valueOf(record, dataType) {
+    if (dataType === 'float' && record.value_float !== null && record.value_float !== undefined) return record.value_float;
+    if (dataType === 'int' && record.value_int !== null && record.value_int !== undefined) return record.value_int;
+    if ((dataType === 'string' || dataType === 'text') && record.value_string !== null && record.value_string !== undefined) return record.value_string;
+    if (record.value_string !== null && record.value_string !== undefined && record.value_string !== '') return record.value_string;
+    if (record.value_float !== null && record.value_float !== undefined) return record.value_float;
+    if (record.value_int !== null && record.value_int !== undefined) return record.value_int;
+    return '';
+  }
+
+  function mapForDevices(deviceParameters, deviceIds, parameters) {
+    var allowed = new Set((deviceIds || []).map(DataUtils.normalizeId));
+    var types = new Map((parameters || []).map(function(parameter) {
+      return [DataUtils.normalizeId(parameter.id), parameter.dataType || parameter.data_type];
+    }));
+    var result = new Map();
+    (deviceParameters || []).forEach(function(record) {
+      var deviceId = DataUtils.normalizeId(record.device_id);
+      if (!allowed.has(deviceId)) return;
+      if (!result.has(deviceId)) result.set(deviceId, new Map());
+      var parameterId = DataUtils.normalizeId(record.parameter_id);
+      result.get(deviceId).set(parameterId, valueOf(record, types.get(parameterId)));
+    });
+    return result;
+  }
+
+  return { mapForDevices: mapForDevices, valueOf: valueOf };
+});

--- a/widget/BDView/js/system-monitor.js
+++ b/widget/BDView/js/system-monitor.js
@@ -1,0 +1,43 @@
+(function(root, factory) {
+  var moduleValue = factory(root.BDViewDataUtils || (typeof require === 'function' ? require('./data-utils.js') : null));
+  if (typeof module === 'object' && module.exports) module.exports = moduleValue;
+  root.SystemMonitor = moduleValue;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function(DataUtils) {
+  'use strict';
+
+  function selectedGroupId(records) {
+    var record = (records || []).find(function(item) { return item.param === 'selectedGroupID'; });
+    return record ? DataUtils.normalizeId(record.value) : null;
+  }
+
+  function create(gristApi, onChange, options) {
+    options = options || {};
+    var interval = options.interval || 750;
+    var timer = null;
+    var stopped = true;
+    var current;
+
+    async function check() {
+      if (stopped) return;
+      try {
+        var next = selectedGroupId(DataUtils.rows(await gristApi.docApi.fetchTable('SYSTEM')));
+        if (next !== current) {
+          current = next;
+          await onChange(next);
+        }
+      } catch (error) {
+        if (options.onError) options.onError(error);
+      } finally {
+        if (!stopped) timer = setTimeout(check, interval);
+      }
+    }
+
+    return {
+      start: function() { if (stopped) { stopped = false; check(); } },
+      stop: function() { stopped = true; if (timer) clearTimeout(timer); },
+      check: check
+    };
+  }
+
+  return { create: create, selectedGroupId: selectedGroupId };
+});

--- a/widget/BDView/js/table-builder.js
+++ b/widget/BDView/js/table-builder.js
@@ -1,0 +1,37 @@
+(function(root, factory) {
+  var moduleValue = factory(root.BDViewDataUtils || (typeof require === 'function' ? require('./data-utils.js') : null));
+  if (typeof module === 'object' && module.exports) module.exports = moduleValue;
+  root.TableBuilder = moduleValue;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function(DataUtils) {
+  'use strict';
+
+  function field(parameterId) { return 'parameter_' + parameterId; }
+
+  function columns(parameters) {
+    return (parameters || []).map(function(parameter) {
+      return {
+        title: parameter.name + (parameter.unit ? ', ' + parameter.unit : ''),
+        field: field(parameter.id),
+        sorter: parameter.dataType === 'float' || parameter.dataType === 'int' ? 'number' : 'string',
+        headerFilter: 'input',
+        headerFilterFunc: 'like',
+        headerFilterLiveFilter: true,
+        headerSort: true
+      };
+    });
+  }
+
+  function rows(devices, parameters, valueMap) {
+    return (devices || []).map(function(device) {
+      var deviceId = DataUtils.normalizeId(device.id);
+      var values = valueMap.get(deviceId) || new Map();
+      var row = { id: deviceId };
+      (parameters || []).forEach(function(parameter) {
+        row[field(parameter.id)] = values.has(parameter.id) ? values.get(parameter.id) : '';
+      });
+      return row;
+    });
+  }
+
+  return { columns: columns, rows: rows, field: field };
+});

--- a/widget/BDView/js/table-view.js
+++ b/widget/BDView/js/table-view.js
@@ -1,0 +1,25 @@
+(function(root, factory) {
+  var moduleValue = factory();
+  if (typeof module === 'object' && module.exports) module.exports = moduleValue;
+  root.TableView = moduleValue;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function() {
+  'use strict';
+  var table = null;
+
+  function rebuild(columns, rows) {
+    if (table) table.destroy();
+    table = new Tabulator('#device-table', {
+      data: rows,
+      columns: columns,
+      layout: 'fitDataStretch',
+      height: '100%',
+      placeholder: 'В выбранной категории нет устройств',
+      renderVertical: 'virtual',
+      columnDefaults: { headerSortStartingDir: 'asc' }
+    });
+    return table;
+  }
+
+  function clear() { return rebuild([], []); }
+  return { rebuild: rebuild, clear: clear, getTable: function() { return table; } };
+});

--- a/widget/BDView/tests/providers.test.js
+++ b/widget/BDView/tests/providers.test.js
@@ -1,0 +1,59 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const CategoryTree = require('../js/category-tree.js');
+const ColumnProvider = require('../js/column-provider.js');
+const DeviceProvider = require('../js/device-provider.js');
+const ParameterProvider = require('../js/parameter-provider.js');
+const TableBuilder = require('../js/table-builder.js');
+const SystemMonitor = require('../js/system-monitor.js');
+
+test('reads selectedGroupID and normalizes Grist reference values', () => {
+  assert.equal(SystemMonitor.selectedGroupId([
+    { param: 'other', value: 3 },
+    { param: 'selectedGroupID', value: ['L', 21] }
+  ]), 21);
+  assert.equal(SystemMonitor.selectedGroupId([]), null);
+});
+
+test('recursively includes every descendant and terminates on cycles', () => {
+  const categories = [
+    { id: 2, parent_id: 0 }, { id: 20, parent_id: 2 },
+    { id: 21, parent_id: 20 }, { id: 2, parent_id: 21 }, { id: 99, parent_id: 0 }
+  ];
+  assert.deepEqual(CategoryTree.descendantIds(categories, '2'), [2, 20, 21]);
+});
+
+test('builds ordered schema-driven columns with live substring filters', () => {
+  const links = [
+    { category_id: 2, parameter_id: 4, manualSort: 3 },
+    { category_id: 2, parameter_id: 1, manualSort: 1 },
+    { category_id: 20, parameter_id: 2, manualSort: 2 }
+  ];
+  const definitions = [
+    { id: 1, name: 'Мощность', unit: 'Вт', data_type: 'float' },
+    { id: 2, name: 'Напряжение', unit: 'В', data_type: 'float' },
+    { id: 4, name: 'IP', unit: '', data_type: 'string' }
+  ];
+  const parameters = ColumnProvider.forCategory(links, definitions, 2);
+  assert.deepEqual(parameters.map((item) => item.id), [1, 4]);
+  assert.deepEqual(TableBuilder.columns(parameters), [
+    { title: 'Мощность, Вт', field: 'parameter_1', sorter: 'number', headerFilter: 'input', headerFilterFunc: 'like', headerFilterLiveFilter: true, headerSort: true },
+    { title: 'IP', field: 'parameter_4', sorter: 'string', headerFilter: 'input', headerFilterFunc: 'like', headerFilterLiveFilter: true, headerSort: true }
+  ]);
+});
+
+test('filters descendant devices and maps typed parameters in one pass', () => {
+  const devices = DeviceProvider.forCategories([
+    { id: 10, categories_id: 2 }, { id: 11, categories_id: 20 }, { id: 12, categories_id: 99 }
+  ], [2, 20, 21]);
+  const values = ParameterProvider.mapForDevices([
+    { device_id: 10, parameter_id: 1, value_float: 10, value_int: 0, value_string: '' },
+    { device_id: 10, parameter_id: 4, value_float: null, value_int: null, value_string: 'IP54' },
+    { device_id: 11, parameter_id: 5, value_float: null, value_int: 4000, value_string: '' },
+    { device_id: 12, parameter_id: 4, value_float: null, value_int: null, value_string: 'ignored' }
+  ], devices.map((device) => device.id), [{ id: 1, dataType: 'float' }, { id: 4, dataType: 'string' }, { id: 5, dataType: 'int' }]);
+  assert.deepEqual(TableBuilder.rows(devices, [{ id: 1 }, { id: 4 }, { id: 5 }], values), [
+    { id: 10, parameter_1: 10, parameter_4: 'IP54', parameter_5: '' },
+    { id: 11, parameter_1: '', parameter_4: '', parameter_5: 4000 }
+  ]);
+});

--- a/widget/BDView/widget.json
+++ b/widget/BDView/widget.json
@@ -1,0 +1,14 @@
+{
+  "name": "BDView",
+  "description": "Динамический каталог устройств выбранной категории",
+  "version": "1.0.0",
+  "grist": {
+    "name": "BDView",
+    "url": "index.html",
+    "widgetId": "bdview",
+    "published": true
+  },
+  "options": {
+    "requiredAccess": "full"
+  }
+}


### PR DESCRIPTION
## Что реализовано

- Добавлен виджет `widget/BDView` на Tabulator с `fitDataStretch`, виртуализацией, сортировкой и живыми фильтрами `contains` для каждого динамического столбца.
- `SystemMonitor` без перезагрузки отслеживает `SYSTEM.selectedGroupID` и запускает полное перестроение таблицы.
- `CategoryTree` рекурсивно и с защитой от циклов включает выбранную категорию и потомков любой глубины.
- `ColumnProvider` формирует столбцы только из `CategoryParameters` в порядке `manualSort`.
- `DeviceProvider` и `ParameterProvider` загружают таблицы пакетно; значения `float`/`int`/`string` выбираются по `Parameters.data_type`, без N+1 запросов.
- Архитектура разделена на требуемые независимые модули: SystemMonitor, CategoryTree, ColumnProvider, DeviceProvider, ParameterProvider, TableBuilder и TableView.

## Как воспроизвести

1. В `SYSTEM` задать `param = selectedGroupID` и ID родительской категории в `value`.
2. Открыть `widget/BDView/index.html` как Custom Widget.
3. Убедиться, что показаны устройства выбранной категории и всех потомков, а колонки соответствуют `CategoryParameters`.
4. Изменить `selectedGroupID` через BDTree: таблица перестраивается без перезагрузки.

## Проверка

- `node --test widget/BDView/tests/*.test.js` — 4/4 теста проходят.
- `node experiments/verify-bdview-database.js` — проверка на `BDNEW_ZCAD.grist` проходит (9 категорий, 3 столбца, 1 строка для категории 2).
- `node --check widget/BDView/js/*.js` — синтаксис проверен.
- `git diff --check` — ошибок форматирования нет.

Fixes veb86/GristWidgets#31
