### PR TITLE
Исправлена загрузка Grist API в BDView

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-31T12:37:51.556Z for PR creation at branch issue-33-61e2d3441263 for issue https://github.com/veb86/GristWidgets/issues/33

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-31T12:37:51.556Z for PR creation at branch issue-33-61e2d3441263 for issue https://github.com/veb86/GristWidgets/issues/33

--- a/widget/BDView/index.html
+++ b/widget/BDView/index.html
@@ -13,7 +13,7 @@
     <div id="message" aria-live="polite"></div>
     <div id="device-table"></div>
   </main>
-  <script src="./grist-plugin-api.js"></script>
+  <script src="../edittable/grist-plugin-api.js"></script>
   <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
   <script src="./js/data-utils.js"></script>
   <script src="./js/system-monitor.js"></script>

--- a/widget/BDView/tests/assets.test.js
+++ b/widget/BDView/tests/assets.test.js
@@ -1,0 +1,20 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const widgetDirectory = path.resolve(__dirname, '..');
+
+test('every local script referenced by index.html exists', () => {
+  const html = fs.readFileSync(path.join(widgetDirectory, 'index.html'), 'utf8');
+  const sources = Array.from(html.matchAll(/<script\b[^>]*\bsrc=["']([^"']+)["']/gi), (match) => match[1]);
+  const localSources = sources.filter((source) => !/^(?:[a-z]+:)?\/\//i.test(source));
+
+  assert.ok(localSources.length > 0, 'index.html should reference local scripts');
+  for (const source of localSources) {
+    assert.ok(
+      fs.existsSync(path.resolve(widgetDirectory, source)),
+      `Local script does not exist: ${source}`
+    );
+  }
+});


### PR DESCRIPTION
## Что исправлено

- Исправлен путь к локальному комплекту Grist Plugin API: BDView теперь загружает существующий `widget/edittable/grist-plugin-api.js`.
- Добавлен регрессионный тест, проверяющий существование всех локальных JavaScript-файлов, подключённых из `widget/BDView/index.html`.

## Как воспроизвести ошибку

1. Открыть `widget/BDView/index.html` как Custom Widget.
2. До исправления браузер запрашивал отсутствующий `widget/BDView/grist-plugin-api.js` и получал `404`.
3. Следующий скрипт `app.js` завершался с `ReferenceError: grist is not defined`.

После исправления Grist API загружается из существующего локального файла до запуска `app.js`.

## Проверка

- `node --test widget/BDView/tests/*.test.js` — 5/5 тестов проходят.
- `node --check widget/BDView/js/*.js` — все JavaScript-модули синтаксически корректны.
- `node experiments/verify-bdview-database.js` — проверка на `BDNEW_ZCAD.grist` проходит (9 категорий, 3 столбца, 1 строка).
- `git diff --check upstream/main...HEAD` — ошибок форматирования нет.

Fixes veb86/GristWidgets#33
