### PR TITLE
BDView: добавлены постоянные колонки устройств

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-31T13:28:50.274Z for PR creation at branch issue-35-aa4a58c3ff01 for issue https://github.com/veb86/GristWidgets/issues/35

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-31T13:28:50.274Z for PR creation at branch issue-35-aa4a58c3ff01 for issue https://github.com/veb86/GristWidgets/issues/35

--- a/experiments/verify-bdview-database.js
+++ b/experiments/verify-bdview-database.js
@@ -20,10 +20,20 @@ const categoryIds = CategoryTree.descendantIds(categories, 2);
 const selectedParameters = ColumnProvider.forCategory(categoryParameters, parameters, 2);
 const selectedDevices = DeviceProvider.forCategories(devices, categoryIds);
 const values = ParameterProvider.mapForDevices(deviceParameters, selectedDevices.map((device) => device.id), selectedParameters);
+const columns = TableBuilder.columns(selectedParameters);
 const rows = TableBuilder.rows(selectedDevices, selectedParameters, values);
 
 assert.ok(categoryIds.includes(2));
 assert.deepEqual(selectedParameters.map((parameter) => parameter.name), ['Мощность', 'Напряжение', 'Цветовая температура']);
+assert.deepEqual(columns.map((column) => column.field), ['name', 'model', 'manufacturer', 'parameter_1', 'parameter_2', 'parameter_4']);
 assert.equal(rows.length, 1);
-assert.deepEqual(rows[0], { id: 1, parameter_1: 10, parameter_2: 220, parameter_4: 4000 });
-console.log('BDView database verification passed:', { categoryIds: categoryIds.length, columns: selectedParameters.length, rows: rows.length });
+assert.deepEqual(rows[0], {
+  id: 1,
+  name: 'LED лампа 10Вт ',
+  model: 'A60-10W',
+  manufacturer: 'Philips',
+  parameter_1: 10,
+  parameter_2: 220,
+  parameter_4: 4000
+});
+console.log('BDView database verification passed:', { categoryIds: categoryIds.length, columns: columns.length, rows: rows.length });

--- a/widget/BDView/README.md
+++ b/widget/BDView/README.md
@@ -2,7 +2,7 @@
 
 Виджет Grist Desktop строит таблицу устройств по категории, выбранной в `SYSTEM.selectedGroupID`.
 
-Колонки берутся из `CategoryParameters` в порядке `manualSort`; строки включают устройства выбранной категории и всех её потомков. Значения загружаются одним чтением `DeviceParameters`, затем сопоставляются в памяти. Каждый столбец поддерживает сортировку и регистронезависимый поиск по части текста средствами Tabulator.
+Первые три постоянные колонки — `name`, `model`, `manufacturer` из таблицы `Devices`. После них добавляются колонки из `CategoryParameters` в порядке `manualSort`; строки включают устройства выбранной категории и всех её потомков. Значения загружаются одним чтением `DeviceParameters`, затем сопоставляются в памяти. Каждый столбец поддерживает сортировку и регистронезависимый поиск по части текста средствами Tabulator.
 
 ## Таблицы
 
@@ -10,7 +10,7 @@
 - `Categories`: `parent_id`.
 - `CategoryParameters`: `category_id`, `parameter_id`, `manualSort`.
 - `Parameters`: `name`, `unit`, `data_type`.
-- `Devices`: `categories_id`.
+- `Devices`: `categories_id`, `name`, `model`, `manufacturer`.
 - `DeviceParameters`: `device_id`, `parameter_id`, `value_float`, `value_int`, `value_string`.
 
 Добавьте Custom Widget с URL `widget/BDView/index.html` и предоставьте доступ к документу. Виджет проверяет `SYSTEM` без перезагрузки страницы и полностью перестраивает Tabulator при смене категории.

--- a/widget/BDView/js/table-builder.js
+++ b/widget/BDView/js/table-builder.js
@@ -5,20 +5,35 @@
 })(typeof globalThis !== 'undefined' ? globalThis : this, function(DataUtils) {
   'use strict';
 
+  var DEVICE_COLUMNS = [
+    { title: 'Наименование', field: 'name' },
+    { title: 'Модель', field: 'model' },
+    { title: 'Производитель', field: 'manufacturer' }
+  ];
+
   function field(parameterId) { return 'parameter_' + parameterId; }
 
+  function column(title, columnField, sorter) {
+    return {
+      title: title,
+      field: columnField,
+      sorter: sorter,
+      headerFilter: 'input',
+      headerFilterFunc: 'like',
+      headerFilterLiveFilter: true,
+      headerSort: true
+    };
+  }
+
   function columns(parameters) {
-    return (parameters || []).map(function(parameter) {
-      return {
-        title: parameter.name + (parameter.unit ? ', ' + parameter.unit : ''),
-        field: field(parameter.id),
-        sorter: parameter.dataType === 'float' || parameter.dataType === 'int' ? 'number' : 'string',
-        headerFilter: 'input',
-        headerFilterFunc: 'like',
-        headerFilterLiveFilter: true,
-        headerSort: true
-      };
+    var deviceColumns = DEVICE_COLUMNS.map(function(deviceColumn) {
+      return column(deviceColumn.title, deviceColumn.field, 'string');
     });
+    var parameterColumns = (parameters || []).map(function(parameter) {
+      var sorter = parameter.dataType === 'float' || parameter.dataType === 'int' ? 'number' : 'string';
+      return column(parameter.name + (parameter.unit ? ', ' + parameter.unit : ''), field(parameter.id), sorter);
+    });
+    return deviceColumns.concat(parameterColumns);
   }
 
   function rows(devices, parameters, valueMap) {
@@ -26,6 +41,10 @@
       var deviceId = DataUtils.normalizeId(device.id);
       var values = valueMap.get(deviceId) || new Map();
       var row = { id: deviceId };
+      DEVICE_COLUMNS.forEach(function(deviceColumn) {
+        var value = device[deviceColumn.field];
+        row[deviceColumn.field] = value === null || value === undefined ? '' : value;
+      });
       (parameters || []).forEach(function(parameter) {
         row[field(parameter.id)] = values.has(parameter.id) ? values.get(parameter.id) : '';
       });

--- a/widget/BDView/tests/providers.test.js
+++ b/widget/BDView/tests/providers.test.js
@@ -23,7 +23,7 @@ test('recursively includes every descendant and terminates on cycles', () => {
   assert.deepEqual(CategoryTree.descendantIds(categories, '2'), [2, 20, 21]);
 });
 
-test('builds ordered schema-driven columns with live substring filters', () => {
+test('prepends permanent device columns to ordered schema-driven columns', () => {
   const links = [
     { category_id: 2, parameter_id: 4, manualSort: 3 },
     { category_id: 2, parameter_id: 1, manualSort: 1 },
@@ -37,6 +37,9 @@ test('builds ordered schema-driven columns with live substring filters', () => {
   const parameters = ColumnProvider.forCategory(links, definitions, 2);
   assert.deepEqual(parameters.map((item) => item.id), [1, 4]);
   assert.deepEqual(TableBuilder.columns(parameters), [
+    { title: 'Наименование', field: 'name', sorter: 'string', headerFilter: 'input', headerFilterFunc: 'like', headerFilterLiveFilter: true, headerSort: true },
+    { title: 'Модель', field: 'model', sorter: 'string', headerFilter: 'input', headerFilterFunc: 'like', headerFilterLiveFilter: true, headerSort: true },
+    { title: 'Производитель', field: 'manufacturer', sorter: 'string', headerFilter: 'input', headerFilterFunc: 'like', headerFilterLiveFilter: true, headerSort: true },
     { title: 'Мощность, Вт', field: 'parameter_1', sorter: 'number', headerFilter: 'input', headerFilterFunc: 'like', headerFilterLiveFilter: true, headerSort: true },
     { title: 'IP', field: 'parameter_4', sorter: 'string', headerFilter: 'input', headerFilterFunc: 'like', headerFilterLiveFilter: true, headerSort: true }
   ]);
@@ -44,7 +47,9 @@ test('builds ordered schema-driven columns with live substring filters', () => {
 
 test('filters descendant devices and maps typed parameters in one pass', () => {
   const devices = DeviceProvider.forCategories([
-    { id: 10, categories_id: 2 }, { id: 11, categories_id: 20 }, { id: 12, categories_id: 99 }
+    { id: 10, categories_id: 2, name: 'Светильник', model: 'L-10', manufacturer: 'Завод 1' },
+    { id: 11, categories_id: 20, name: 'Автомат', model: null, manufacturer: 'Завод 2' },
+    { id: 12, categories_id: 99, name: 'Розетка', model: 'R-12', manufacturer: 'Завод 3' }
   ], [2, 20, 21]);
   const values = ParameterProvider.mapForDevices([
     { device_id: 10, parameter_id: 1, value_float: 10, value_int: 0, value_string: '' },
@@ -53,7 +58,7 @@ test('filters descendant devices and maps typed parameters in one pass', () => {
     { device_id: 12, parameter_id: 4, value_float: null, value_int: null, value_string: 'ignored' }
   ], devices.map((device) => device.id), [{ id: 1, dataType: 'float' }, { id: 4, dataType: 'string' }, { id: 5, dataType: 'int' }]);
   assert.deepEqual(TableBuilder.rows(devices, [{ id: 1 }, { id: 4 }, { id: 5 }], values), [
-    { id: 10, parameter_1: 10, parameter_4: 'IP54', parameter_5: '' },
-    { id: 11, parameter_1: '', parameter_4: '', parameter_5: 4000 }
+    { id: 10, name: 'Светильник', model: 'L-10', manufacturer: 'Завод 1', parameter_1: 10, parameter_4: 'IP54', parameter_5: '' },
+    { id: 11, name: 'Автомат', model: '', manufacturer: 'Завод 2', parameter_1: '', parameter_4: '', parameter_5: 4000 }
   ]);
 });

--- a/widget/BDView/widget.json
+++ b/widget/BDView/widget.json
@@ -1,7 +1,7 @@
 {
   "name": "BDView",
   "description": "Динамический каталог устройств выбранной категории",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "grist": {
     "name": "BDView",
     "url": "index.html",


### PR DESCRIPTION
## Что изменено

- Перед динамическими параметрами добавлены три постоянные колонки из `Devices`: `name`, `model`, `manufacturer` — строго в указанном порядке.
- Значения этих полей включены в строки Tabulator; отсутствующие значения отображаются пустой строкой.
- Постоянные колонки поддерживают ту же сортировку и живые текстовые фильтры, что и остальные столбцы.
- Обновлены документация BDView, проверка на реальной базе и версия виджета до `1.1.0`.

## Как воспроизвести проблему

1. Выбрать категорию через `SYSTEM.selectedGroupID`.
2. Открыть `widget/BDView/index.html`.
3. До исправления таблица начиналась с динамических полей `CategoryParameters`, хотя значения `name`, `model`, `manufacturer` уже были загружены из `Devices`.

## Автоматическая проверка

- `node --test widget/BDView/tests/*.test.js` — 4/4 теста проходят; тест проверяет порядок постоянных колонок, значения строк и пустое значение для `null`.
- `node experiments/verify-bdview-database.js` — проверка на `BDNEW_ZCAD.grist`: 6 колонок и строка со значениями `name`, `model`, `manufacturer`.
- `node --check widget/BDView/js/*.js` — синтаксис JavaScript корректен.
- `git diff --check` — ошибок форматирования нет.

Fixes veb86/GristWidgets#35